### PR TITLE
Added multiple "scan type" support

### DIFF
--- a/modules/quiet-scan-threaded.py
+++ b/modules/quiet-scan-threaded.py
@@ -3,11 +3,14 @@
 import subprocess
 import sys, getopt, os
 import threading
+import argparse
 
 cwd = os.getcwd()
-path = cwd + "/modules/port_scanner_files/"
+path = cwd + "/port_scanner_files/"
 ip_list_file = path + "input/IP_list.txt"
 nmap_output_file = path + "temp_output/nmap_output"
+#the scorchedearth option runs every nmap scan that doesn't require an additional host OR standard ping scan
+scorchedearth = ["-sS", "-sT", "-sA", "-sW", "-sM", "-sU", "-sN", "-sF", "-sX", "-sY","-sZ", "-sO"]
 
 def module_name():
   return "quiet-scan-threaded"
@@ -33,7 +36,7 @@ def system_call(program_name, args = [], privilege = False):
     subprocess.call(call, shell=True)
 
 
-def parse_nmap_output(ipAddr, nmap_output):
+def parse_nmap_output(ipAddr, scantype, nmap_output):
     services_list = path + "scan_output/services_list" + "_" + ipAddr + ".txt"
     nmap_fp = open(nmap_output, 'r')
 
@@ -43,8 +46,8 @@ def parse_nmap_output(ipAddr, nmap_output):
         line_in = nmap_fp.readline()
         if(line_in.lower().find("nmap done") != -1): #when no ports are open we should exit
             return
-
-    services_fp = open(services_list, 'w')
+    #changed to append, so we can get results from all scan types
+    services_fp = open(services_list, 'a')
 
     line_in = nmap_fp.readline()
             
@@ -62,7 +65,7 @@ def parse_nmap_output(ipAddr, nmap_output):
         line_out_list.extend(str_split_2)
 
         line_out = ' '.join(line_out_list)
-        
+        services_fp.write("Scanned with: " + scantype + "\n")#write what scan produced these results
         services_fp.write(line_out)
 
         line_in = nmap_fp.readline()
@@ -75,25 +78,49 @@ def buildArgs(argv, line, fileName):
     arr = [line.strip()]
     if(len(argv) > 0):
         arr.extend(argv)
+    arr.append("-Pn") #controversial addition: we know all the hosts are going to be online because of the game rules, so adding this skips the host discovery
     arr.extend([">", fileName])
     return arr      
 
-def nmap_worker(line, argv):
+def nmap_worker(line, scantype, standard_args):
+
+    #since we are appending multiple scan results to one file, zero out the file before start
     line = line.strip()
-    print("Starting NMAP Thread for " + line + ":")
-    fileName = nmap_output_file + "_" + line + ".txt"
-    system_call("nmap -sS", buildArgs(argv, line, fileName), True) #-p- to scan all the ports
-    parse_nmap_output(line, fileName)
+    services_list = path + "scan_output/services_list" + "_" + line + ".txt"
+    services_fp = open(services_list, 'w')
+    services_fp.close()
+    
+    if ("scortchedearth" in scantype) or ("se" in scantype):
+    	scantype = scorchedearth
+    for scan in scantype:
+    	
+    	print("Starting NMAP Thread for " + line +":" + " Scantype: " + scan)
+    	fileName = nmap_output_file + "_" + line + ".txt"
+    	system_call(("nmap " + scan), buildArgs(standard_args, line, fileName), True) #-p- to scan all the ports
+    	parse_nmap_output(line, scan, fileName)
 
 
 
-def main(argv):  
+def main():  
     with open(ip_list_file ,'r') as file:
         line = file.readline()
+        
+        #New calling convention is two lists of arguments: the scan type and whatever other arguments there are
+        #example python3 quiet-scan-threaded.py --scantype "-sS -sN" --options "-p 80 -sV"
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--scantype', dest= 'scantype', required=True, help="List all scan types here. Format as if callingi n nmap ie -sS -Su -sM' etc. To automatically run all scan types enter 'scortchedearth' or 'se'")
+        parser.add_argument('--options', dest= 'standard_args', nargs='+', required=True, help="All options other than scan type listed here, just as if calling nmap from the commandline")
+        args = parser.parse_args()
+        standard_args = args.standard_args
+        scans = args.scantype
+        scantype = scans.split(' ')
+
+       	
         while line:
-            t = threading.Thread(target=nmap_worker, args=(line, argv))
+            t = threading.Thread(target=nmap_worker, args=(line, scantype, standard_args))
             t.start()
-            line = file.readline()
+            line = file.readline() 
 
 if __name__ == "__main__":
-  main(sys.argv[1:])
+  main()


### PR DESCRIPTION
1. Easy change: I added -Pn as a hardcoded requirement since we know that the hosts are online, so it should save us some noise/time (line 81)

2. I added "type" selection (and adjusted the fileoutput writes) to allow us to specify one to multiple scan types to the script (and an option called "scorchedearth" or "se" which scans using every single option. I know it will be controversial, but I think it is necessary, since different scans produce vastly different results. Includes "argparse" use, global "scorchedearth" list, 
example run format:
python3 quiet-scan-threaded.py --scantype "se" --options "-p 80"
python3 quiet-scan-threaded.py --scantype "-sS -sN -sU" --options "-p 80 -sV"

Also, I couldn't figure out how to upload a replacement file, so I copy/pasted...apologies if this caused formatting errors